### PR TITLE
RHEL 9 based systems compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Easily install Cisco Packet Tracerin RPM based systems. This installation progra
 ## Tested RPM based systems
 
 - [ ] Alma Linux 8  
-- [ ] Alma Linux 9  
+- [x] Alma Linux 9  
 - [ ] Centos Stream 8  
-- [ ] Centos Stream 9  
+- [x] Centos Stream 9  
 - [x] Fedora 35  
 - [x] Fedora 36  
 - [ ] Fedora 37  
@@ -17,7 +17,7 @@ Easily install Cisco Packet Tracerin RPM based systems. This installation progra
 - [ ] OpenSuse Leap 15.4  
 - [ ] OpenSuse Tumbleweed  
 - [ ] Rocky Linux 8  
-- [ ] Rocky Linux 9  
+- [x] Rocky Linux 9  
 
 ## Install
 

--- a/setup.sh
+++ b/setup.sh
@@ -28,12 +28,9 @@ DEPS=(
   'qt5-qtsvg.x86_64'          \
   'qt5-qtspeech'              \
 )
+INSTALLER_BASENAME=''
+IS_RHEL_BASED=0
 LOCALIZED_VERSIONS=()
-OPENSUSE=(
-  'SUSE Linux'            \
-  'OpenSUSE Leap'         \
-  'OpenSUSE Tumbleweed'   \
-)
 OS_VERSION=`sed -n '/^NAME/p' /etc/os-release |\
             cut -f2 -d '=' |\
             sed 's/"// g'`
@@ -46,6 +43,11 @@ RHEL_LIKE=(
   'CentOS Linux'              \
   'Rocky Linux'               \
   'Alma Linux'                \
+)
+SUSE=(
+  'SUSE Linux'            \
+  'OpenSUSE Leap'         \
+  'OpenSUSE Tumbleweed'   \
 )
 
 
@@ -83,6 +85,12 @@ install() {
   sudo sed -i 's/packettracer/packettracer --no-sandbox args/' /usr/share/applications/cisco-pt.desktop
   sudo ./packettracer/postinst 
 
+  if [ $IS_RHEL_BASED == 1 ]; then
+    echo "Installing dependencies for RHEL based..."
+    sleep 1
+    sudo dnf install -y epel-release compat-openssl11
+  fi
+
   echo "Installing dependecies..."
   sleep 2
   sudo $PACKAGE_MANAGER install -y "${DEPS[@]}"
@@ -93,18 +101,8 @@ install() {
 locate_installers() {
   c=1
   for installer in $(sudo find /home -type f -name 'CiscoPacketTracer*'); do
-    listed_path=($(sed 's/\// /g' <<< $installer))
-    # listed_path run a regex that separe path with spaces
-    # and turn it into a list to be used in cut cmd for get
-    # the version value. Ex:
-    # /home/user/Documents/CiscoPacketTracer_820_Ubuntu_64bit.deb
-    # ( home user Documents CiscoPakcetTracer_820_Ubuntu_64bit.deb )
-    #                      '--------------------------------------'
-    #                                         |
-    #                                         V
-    #                                last position in the list
-    #                      cut -f2 -d "_" <<< ${listed_path[-1]}
-    version=$(cut -f2 -d "_" <<< ${listed_path[-1]})
+    INSTALLER_BASENAME=`basename $installer`
+    version=$(cut -f2 -d "_" <<< $INSTALLER_BASENAME)
     LOCALIZED_VERSIONS[$c]=$version
     LOCALIZED_INSTALLERS[$c]=$installer
     ((c++))
@@ -162,9 +160,14 @@ uninstall() {
 # to be used to install dependencies
 for os in "${RHEL_LIKE[@]}"; do
   if [ "$OS_VERSION" == "$os" ]; then
-    PACKAGE_MANAGER="yum"
+    PACKAGE_MANAGER="dnf"
+
+    if [[ $os == "CentOS Linux" ]] || [[ $os == "Rocky Linux" ]]; then
+      IS_RHEL_BASED=1
+    fi
+
   else
-    for os in "${OPENSUSE}"; do
+    for os in "${SUSE[@]}"; do
       if [ "$OS_VERSION" == "$os" ]; then
         PACKAGE_MANAGER="zypper"
       fi
@@ -195,7 +198,7 @@ while : ; do
         dialog --backtitle "$BACKTITLE on $OS_VERSION" \
         --yesno "Do you want to install the \
         ${LOCALIZED_VERSIONS[$select_version]} \
-        do Cisco Packet Tracer?" \
+        version of Cisco Packet Tracer?" \
         6 60
         
         if [ $? = 0 ]; then
@@ -206,7 +209,6 @@ while : ; do
           --msgbox "Cisco Packet Tracer ${LOCALIZED_VERSIONS[$((select_version))]} was installed." \
           6 40
           break
-
         fi
       ;;
     2 ) dialog --backtitle "$BACKTITLE on $OS_VERSION" \


### PR DESCRIPTION
With this commit all distributions based on RHEL 9 will be able to install Packet Tracer.